### PR TITLE
Moved save button to be a part of the main table display

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import React from 'react';
 import './App.css';
 import Clear from '@material-ui/icons/Clear';
 import MutantDisplay from './MutantDisplay.js';
-import Download from '@axetroy/react-download';
 
 function ErrorMessage(props) {
   //return <div>{ props.message } <button onClick={ props.clearError }>Close</button></div>
@@ -77,19 +76,6 @@ class App extends React.Component {
     this.setState({ mutants: newMutants });
   }
 
-  mutationButton() {
-    if (this.state.mutants.length == 0) {
-      return null;
-    }
-    return (
-      <button>
-        <Download file={this.fileInput.files[0].name} content={JSON.stringify(this.state.mutants)}>
-          Save Mutation Data
-        </Download>
-      </button>
-    );
-  }
-
   render() {
     return (
       <div className='App'>
@@ -99,11 +85,8 @@ class App extends React.Component {
             <input ref={(ref) => { this.fileInput = ref; }} type='file' />
             <button>Upload</button>
           </form>
-          <br></br>
-            <div>{this.mutationButton()}</div>
-          <br></br>
         </div>
-        <MutantDisplay mutants={ this.state.mutants } updateMutantHandler={this.updateMutantHandler.bind(this)} />
+        <MutantDisplay mutants={this.state.mutants} updateMutantHandler={this.updateMutantHandler.bind(this)} />
         {this.createErrorMessage()}
       </div>
     );

--- a/src/MutantDisplay.js
+++ b/src/MutantDisplay.js
@@ -6,7 +6,7 @@ import MutantTable from './MutantTable';
 import MutantCode from './MutantCode';
 import SwitchesGroup from './SwitchesGroup';
 import MutantKillers from './MutantKillers';
-
+import Download from '@axetroy/react-download';
 
 /* Component that handles the displaying of mutants and the logic to navigate
  * around the mutant interface
@@ -45,11 +45,23 @@ class MutantDisplay extends React.Component {
                     <MutantKillers killers = {mutant_obj.killers} />
                 </div>
             );
-        } else {
+        } else if (this.props.mutants.length > 0) {
             return (
-                <MutantTable mutants={this.props.mutants}
-                    mutantClickHandler={this.mutantClickHandler.bind(this)} />
+                <div>
+                    <br/><div style={{"text-align": "center"}}>
+                        <button>
+                            <Download file="mutation_data.json" 
+                                content={JSON.stringify(this.state.mutants)}>
+                                Save Mutation Data
+                            </Download>
+                        </button>
+                    </div><br/>
+                    <MutantTable mutants={this.props.mutants}
+                        mutantClickHandler={this.mutantClickHandler.bind(this)} />
+                </div>
             );
+        } else {
+            return null;
         }
     };
 }

--- a/src/MutantDisplay.js
+++ b/src/MutantDisplay.js
@@ -51,7 +51,7 @@ class MutantDisplay extends React.Component {
                     <br/><div style={{"text-align": "center"}}>
                         <button>
                             <Download file="mutation_data.json" 
-                                content={JSON.stringify(this.state.mutants)}>
+                                content={JSON.stringify(this.props.mutants)}>
                                 Save Mutation Data
                             </Download>
                         </button>


### PR DESCRIPTION
I think it makes the most sense to just have the save mutation data button as part of the main table display since the individual mutant components are more like editing the properties of an individual element and the initial landing page has no data to save yet so it would be an error to click it.